### PR TITLE
Ensure assignment prose code snippets use grey background

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -133,7 +133,8 @@ img { max-width: 100%; height: auto; }
 }
 .markdown pre,
 .editor-preview pre,
-.editor-preview-side pre {
+.editor-preview-side pre,
+.prose pre {
   background: #f0f0f0;
   border: 1px solid hsl(var(--bc) / 0.12);
   border-radius: 0.75rem;
@@ -146,7 +147,8 @@ img { max-width: 100%; height: auto; }
 }
 .markdown pre code,
 .editor-preview pre code,
-.editor-preview-side pre code {
+.editor-preview-side pre code,
+.prose pre code {
   background: none;
   padding: 0;
   border-radius: 0;
@@ -154,7 +156,8 @@ img { max-width: 100%; height: auto; }
 }
 .markdown :not(pre) > code,
 .editor-preview :not(pre) > code,
-.editor-preview-side :not(pre) > code {
+.editor-preview-side :not(pre) > code,
+.prose :not(pre) > code {
   background: #f0f0f0;
   border: 1px solid hsl(var(--bc) / 0.12);
   border-radius: 0.5rem;
@@ -172,14 +175,16 @@ body.hide-navbar .navbar {
 @media (prefers-color-scheme: dark) {
   .markdown pre,
   .editor-preview pre,
-  .editor-preview-side pre {
+  .editor-preview-side pre,
+  .prose pre {
     background: rgba(255, 255, 255, 0.04);
     border-color: rgba(255, 255, 255, 0.14);
     box-shadow: none;
   }
   .markdown :not(pre) > code,
   .editor-preview :not(pre) > code,
-  .editor-preview-side :not(pre) > code {
+  .editor-preview-side :not(pre) > code,
+  .prose :not(pre) > code {
     background: rgba(255, 255, 255, 0.08);
     border-color: rgba(255, 255, 255, 0.18);
   }


### PR DESCRIPTION
## Summary
- extend shared markdown styles to also target prose-rendered assignment descriptions
- ensure both inline and block code previews render on a gray background in light and dark themes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd89d72388321a4d732f720cd3a3f