### PR TITLE
Add function-based testing support and AI integration

### DIFF
--- a/backend/function_runner.go
+++ b/backend/function_runner.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type functionCallConfig struct {
+	FunctionName string
+	ArgsJSON     *string
+	KwargsJSON   *string
+	ExpectedJSON *string
+}
+
+type functionCallResult struct {
+	Status       string  `json:"status"`
+	Passed       bool    `json:"passed"`
+	ReturnJSON   *string `json:"return_json"`
+	ReturnRepr   string  `json:"return_repr"`
+	Stdout       string  `json:"stdout"`
+	Exception    string  `json:"exception"`
+	Traceback    string  `json:"traceback"`
+	ExpectedJSON *string `json:"expected_json"`
+	ExpectedRepr *string `json:"expected_repr"`
+}
+
+func writeFunctionRunnerFiles(dir, mainFile string, cfg functionCallConfig) (string, string, error) {
+	payload := map[string]any{
+		"module_path":   fmt.Sprintf("/code/%s", strings.ReplaceAll(mainFile, "\\", "/")),
+		"function_name": cfg.FunctionName,
+	}
+	if cfg.ArgsJSON != nil && strings.TrimSpace(*cfg.ArgsJSON) != "" {
+		var parsed any
+		if err := json.Unmarshal([]byte(*cfg.ArgsJSON), &parsed); err != nil {
+			return "", "", fmt.Errorf("invalid function args JSON: %w", err)
+		}
+		payload["args"] = parsed
+	}
+	if cfg.KwargsJSON != nil && strings.TrimSpace(*cfg.KwargsJSON) != "" {
+		var parsed any
+		if err := json.Unmarshal([]byte(*cfg.KwargsJSON), &parsed); err != nil {
+			return "", "", fmt.Errorf("invalid function kwargs JSON: %w", err)
+		}
+		payload["kwargs"] = parsed
+	}
+	if cfg.ExpectedJSON != nil && strings.TrimSpace(*cfg.ExpectedJSON) != "" {
+		var parsed any
+		if err := json.Unmarshal([]byte(*cfg.ExpectedJSON), &parsed); err != nil {
+			return "", "", fmt.Errorf("invalid expected return JSON: %w", err)
+		}
+		payload["expected"] = parsed
+	}
+
+	configPath := filepath.Join(dir, "function_config.json")
+	runnerPath := filepath.Join(dir, "function_runner.py")
+
+	cfgBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", err
+	}
+	if err := os.WriteFile(configPath, cfgBytes, 0644); err != nil {
+		return "", "", err
+	}
+
+	script := `import contextlib
+import importlib.util
+import io
+import json
+import sys
+import traceback
+
+MARKER = "===GRADER_JSON==="
+
+
+def load_module(path: str):
+    spec = importlib.util.spec_from_file_location("student_module", path)
+    module = importlib.util.module_from_spec(spec)
+    loader = spec.loader
+    assert loader is not None
+    loader.exec_module(module)
+    return module
+
+
+def resolve_attr(root, dotted: str):
+    target = root
+    for part in dotted.split('.'):
+        target = getattr(target, part)
+    return target
+
+
+def main():
+    with open('function_config.json', 'r', encoding='utf-8') as fh:
+        cfg = json.load(fh)
+
+    result = {"status": "ok", "passed": False}
+    module_stdout = io.StringIO()
+    call_stdout = io.StringIO()
+
+    try:
+        with contextlib.redirect_stdout(module_stdout):
+            module = load_module(cfg['module_path'])
+        func = resolve_attr(module, cfg['function_name'])
+        args = cfg.get('args') or []
+        kwargs = cfg.get('kwargs') or {}
+
+        with contextlib.redirect_stdout(call_stdout):
+            value = func(*args, **kwargs)
+
+        result['passed'] = True
+        sentinel = object()
+        expected = cfg.get('expected', sentinel)
+        if expected is not sentinel:
+            try:
+                equal = value == expected
+            except Exception as cmp_exc:  # noqa: BLE001
+                equal = False
+                result['compare_exception'] = repr(cmp_exc)
+            result['passed'] = bool(equal)
+            result['expected_repr'] = repr(expected)
+            try:
+                result['expected_json'] = json.dumps(expected)
+            except TypeError:
+                result['expected_json'] = None
+
+        result['return_repr'] = repr(value)
+        try:
+            result['return_json'] = json.dumps(value)
+        except TypeError:
+            result['return_json'] = None
+
+    except Exception as exc:  # noqa: BLE001
+        result['status'] = 'exception'
+        result['exception'] = repr(exc)
+        result['traceback'] = traceback.format_exc()
+
+    result['stdout'] = module_stdout.getvalue() + call_stdout.getvalue()
+
+    print(MARKER + json.dumps(result))
+    if result['status'] != 'ok':
+        sys.exit(2)
+    if not result.get('passed', False):
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()
+`
+	if err := os.WriteFile(runnerPath, []byte(script), 0644); err != nil {
+		return "", "", err
+	}
+	return configPath, runnerPath, nil
+}
+
+func runFunctionCall(dir, mainFile string, cfg functionCallConfig, timeout time.Duration) (string, string, int, bool, time.Duration, *functionCallResult, error) {
+	_ = ensureDockerImage(pythonImage)
+	configPath, runnerPath, err := writeFunctionRunnerFiles(dir, mainFile, cfg)
+	if err != nil {
+		return "", "", 0, false, 0, nil, err
+	}
+	defer os.Remove(configPath)
+	defer os.Remove(runnerPath)
+	_ = os.Chmod(configPath, 0644)
+	_ = os.Chmod(runnerPath, 0644)
+	_ = ensureSandboxPerms(dir)
+
+	abs, _ := filepath.Abs(dir)
+	script := fmt.Sprintf("start=$(date +%%s%%N); PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 HOME=/tmp LANG=C.UTF-8 python -u /code/%s; status=$?; end=$(date +%%s%%N); echo '===RUNTIME_MS===' $(((end-start)/1000000)); exit $status", filepath.Base(runnerPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout+dockerExtraTime)
+	defer cancel()
+
+	mount := fmt.Sprintf("%s:/code:ro", abs)
+	cmd := exec.CommandContext(ctx, "docker", "run",
+		"--rm", "-i",
+		"--network=none",
+		"--user", dockerUser,
+		"--cpus", dockerCPUs,
+		"--memory", dockerMemory,
+		"--memory-swap", dockerMemory,
+		"--pids-limit", "128",
+		"--read-only",
+		"--cap-drop=ALL",
+		"--security-opt", "no-new-privileges",
+		"--security-opt", "label=disable",
+		"--mount", "type=tmpfs,destination=/tmp,tmpfs-size=16m",
+		"-v", mount,
+		pythonImage, "bash", "-c", script)
+
+	var stdoutBuf, stderrBuf strings.Builder
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	start := time.Now()
+	runErr := cmd.Run()
+	duration := time.Since(start)
+
+	ctxTimedOut := ctx.Err() == context.DeadlineExceeded
+	out := strings.TrimSpace(stdoutBuf.String())
+	var runtime time.Duration
+	if lines := strings.Split(out, "\n"); len(lines) > 0 && strings.HasPrefix(lines[len(lines)-1], "===RUNTIME_MS===") {
+		rstr := strings.TrimSpace(strings.TrimPrefix(lines[len(lines)-1], "===RUNTIME_MS==="))
+		if ms, perr := strconv.Atoi(rstr); perr == nil {
+			runtime = time.Duration(ms) * time.Millisecond
+			out = strings.Join(lines[:len(lines)-1], "\n")
+		} else {
+			runtime = duration
+		}
+	} else {
+		runtime = duration
+	}
+
+	exitCode := 0
+	if runErr != nil {
+		if ee, ok := runErr.(*exec.ExitError); ok {
+			exitCode = ee.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+
+	const marker = "===GRADER_JSON==="
+	var meta *functionCallResult
+	trimmedOut := strings.TrimSpace(out)
+	if idx := strings.LastIndex(trimmedOut, marker); idx != -1 {
+		payload := strings.TrimSpace(trimmedOut[idx+len(marker):])
+		trimmedOut = strings.TrimSpace(trimmedOut[:idx])
+		var tmp functionCallResult
+		if payload != "" {
+			if err := json.Unmarshal([]byte(payload), &tmp); err == nil {
+				meta = &tmp
+			}
+		}
+	}
+
+	timedOut := ctxTimedOut || runtime > timeout
+	stdout := trimmedOut
+	if meta != nil && meta.Stdout != "" {
+		stdout = meta.Stdout
+	}
+
+	return stdout, strings.TrimSpace(stderrBuf.String()), exitCode, timedOut, runtime, meta, nil
+}

--- a/backend/function_runner_test.go
+++ b/backend/function_runner_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteFunctionRunnerFilesValid(t *testing.T) {
+	dir := t.TempDir()
+	mainFile := filepath.Join("student", "solution.py")
+	args := "[2, 3]"
+	kwargs := `{"scale": 2}`
+	expected := "12"
+	cfg := functionCallConfig{
+		FunctionName: "multiply",
+		ArgsJSON:     &args,
+		KwargsJSON:   &kwargs,
+		ExpectedJSON: &expected,
+	}
+
+	configPath, runnerPath, err := writeFunctionRunnerFiles(dir, mainFile, cfg)
+	if err != nil {
+		t.Fatalf("writeFunctionRunnerFiles returned error: %v", err)
+	}
+	if configPath == "" || runnerPath == "" {
+		t.Fatalf("expected config and runner paths, got %q and %q", configPath, runnerPath)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("config is not valid JSON: %v", err)
+	}
+	if payload["module_path"] != "/code/student/solution.py" {
+		t.Fatalf("unexpected module_path: %#v", payload["module_path"])
+	}
+	if payload["function_name"] != "multiply" {
+		t.Fatalf("unexpected function name: %#v", payload["function_name"])
+	}
+
+	script, err := os.ReadFile(runnerPath)
+	if err != nil {
+		t.Fatalf("failed to read runner: %v", err)
+	}
+	if len(script) == 0 {
+		t.Fatalf("runner script is empty")
+	}
+	if !strings.Contains(string(script), "===GRADER_JSON===") {
+		t.Fatalf("runner script missing sentinel marker")
+	}
+}
+
+func TestWriteFunctionRunnerFilesInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	bad := "[1,"
+	cfg := functionCallConfig{FunctionName: "foo", ArgsJSON: &bad}
+	if _, _, err := writeFunctionRunnerFiles(dir, "main.py", cfg); err == nil {
+		t.Fatalf("expected error for invalid JSON, got nil")
+	}
+}

--- a/backend/models_test.go
+++ b/backend/models_test.go
@@ -58,11 +58,11 @@ func TestListAssignmentsForStudent(t *testing.T) {
 	creatorID := uuid.New()
 	assignmentID := uuid.New()
 	classID := uuid.New()
-        rows := sqlmock.NewRows([]string{"id", "title", "description", "created_by", "deadline", "max_points", "grading_policy", "published", "show_traceback", "show_test_details", "template_path", "created_at", "updated_at", "class_id"}).
-                AddRow(assignmentID.String(), "A", "desc", creatorID.String(), now, 100, "all_or_nothing", true, false, false, nil, now, now, classID.String())
+	rows := sqlmock.NewRows([]string{"id", "title", "description", "created_by", "deadline", "max_points", "grading_policy", "published", "show_traceback", "show_test_details", "template_path", "created_at", "updated_at", "class_id"}).
+		AddRow(assignmentID.String(), "A", "desc", creatorID.String(), now, 100, "all_or_nothing", true, false, false, nil, now, now, classID.String())
 
-	// Relaxed regex: accept any selected columns as our query may include additional fields
-        q := `(?s)SELECT.+FROM assignments a.+JOIN class_students cs ON cs.class_id = a.class_id\s+WHERE cs.student_id = \$1 AND a.published = true ORDER BY a\.created_at DESC`
+		// Relaxed regex: accept any selected columns as our query may include additional fields
+	q := `(?s)SELECT.+FROM assignments a.+JOIN class_students cs ON cs.class_id = a.class_id\s+WHERE cs.student_id = \$1 AND a.published = true ORDER BY a\.created_at DESC`
 	mock.ExpectQuery(q).WithArgs(studentID).WillReturnRows(rows)
 
 	list, err := ListAssignments("student", studentID)
@@ -95,8 +95,8 @@ func TestListAssignmentsForTeacher(t *testing.T) {
 	creatorID := uuid.New()
 	assignmentID := uuid.New()
 	classID := uuid.New()
-        rows := sqlmock.NewRows([]string{"id", "title", "description", "created_by", "deadline", "max_points", "grading_policy", "published", "show_traceback", "show_test_details", "template_path", "created_at", "updated_at", "class_id"}).
-                AddRow(assignmentID.String(), "B", "desc", creatorID.String(), now, 100, "all_or_nothing", false, false, false, nil, now, now, classID.String())
+	rows := sqlmock.NewRows([]string{"id", "title", "description", "created_by", "deadline", "max_points", "grading_policy", "published", "show_traceback", "show_test_details", "template_path", "created_at", "updated_at", "class_id"}).
+		AddRow(assignmentID.String(), "B", "desc", creatorID.String(), now, 100, "all_or_nothing", false, false, false, nil, now, now, classID.String())
 
 	q := `SELECT\s+.*\s+FROM assignments a JOIN classes c ON c.id = a.class_id\s+WHERE c.teacher_id = \$1 ORDER BY a.created_at DESC`
 	mock.ExpectQuery(q).WithArgs(teacherID).WillReturnRows(rows)
@@ -110,6 +110,57 @@ func TestListAssignmentsForTeacher(t *testing.T) {
 	}
 	if list[0].ID != assignmentID {
 		t.Fatalf("wrong assignment id: %s", list[0].ID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestCreateTestCaseDefaultsFunctionMode(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to open sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	DB = sqlx.NewDb(db, "sqlmock")
+
+	assignmentID := uuid.New()
+	fn := "multiply"
+	args := "[2, 3]"
+	kwargs := `{"scale": 1}`
+	expected := "6"
+	now := time.Now()
+
+	rows := sqlmock.NewRows([]string{"id", "weight", "time_limit_sec", "memory_limit_kb", "unittest_code", "unittest_name", "execution_mode", "function_name", "function_args", "function_kwargs", "expected_return", "created_at", "updated_at"}).
+		AddRow(uuid.New().String(), 1.0, 1.0, 0, nil, nil, "function", fn, args, kwargs, expected, now, now)
+
+	insertRE := regexp.QuoteMeta(`
+         INSERT INTO test_cases (assignment_id, stdin, expected_stdout, weight, time_limit_sec, unittest_code, unittest_name,
+                                 execution_mode, function_name, function_args, function_kwargs, expected_return)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+         RETURNING id, weight, time_limit_sec, memory_limit_kb, unittest_code, unittest_name,
+                   execution_mode, function_name, function_args, function_kwargs, expected_return, created_at, updated_at`)
+
+	mock.ExpectQuery(insertRE).
+		WithArgs(assignmentID, "", "", 1.0, 1.0, nil, nil, "function", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(rows)
+
+	tc := &TestCase{AssignmentID: assignmentID, Weight: 1}
+	tc.FunctionName = &fn
+	tc.FunctionArgs = &args
+	tc.FunctionKwargs = &kwargs
+	tc.ExpectedReturn = &expected
+
+	if err := CreateTestCase(tc); err != nil {
+		t.Fatalf("CreateTestCase returned error: %v", err)
+	}
+	if tc.ExecutionMode != "function" {
+		t.Fatalf("expected execution_mode 'function', got %q", tc.ExecutionMode)
+	}
+	if tc.TimeLimitSec != 1 {
+		t.Fatalf("expected default time limit of 1 second, got %v", tc.TimeLimitSec)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -96,12 +96,22 @@ CREATE TABLE IF NOT EXISTS test_cases (
   memory_limit_kb INTEGER NOT NULL DEFAULT 65536,
   unittest_code TEXT,
   unittest_name TEXT,
+  execution_mode TEXT NOT NULL DEFAULT 'stdin_stdout',
+  function_name TEXT,
+  function_args TEXT,
+  function_kwargs TEXT,
+  expected_return TEXT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 ALTER TABLE test_cases ADD COLUMN IF NOT EXISTS unittest_code TEXT;
 ALTER TABLE test_cases ADD COLUMN IF NOT EXISTS unittest_name TEXT;
+ALTER TABLE test_cases ADD COLUMN IF NOT EXISTS execution_mode TEXT NOT NULL DEFAULT 'stdin_stdout';
+ALTER TABLE test_cases ADD COLUMN IF NOT EXISTS function_name TEXT;
+ALTER TABLE test_cases ADD COLUMN IF NOT EXISTS function_args TEXT;
+ALTER TABLE test_cases ADD COLUMN IF NOT EXISTS function_kwargs TEXT;
+ALTER TABLE test_cases ADD COLUMN IF NOT EXISTS expected_return TEXT;
 
 DO $$ BEGIN
     CREATE TYPE submission_status AS ENUM ('pending','running','completed','failed');
@@ -142,10 +152,12 @@ CREATE TABLE IF NOT EXISTS results (
   stderr TEXT,
   exit_code INTEGER,
   runtime_ms INTEGER,
+  actual_return TEXT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 ALTER TABLE results ADD COLUMN IF NOT EXISTS stderr TEXT;
 ALTER TABLE results ADD COLUMN IF NOT EXISTS exit_code INTEGER;
+ALTER TABLE results ADD COLUMN IF NOT EXISTS actual_return TEXT;
 
 -- LLM run artifacts per submission attempt
 CREATE TABLE IF NOT EXISTS llm_runs (

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -636,46 +636,102 @@ func runSubmission(id uuid.UUID) {
 	allPass := true
 	totalWeight := 0.0
 	earnedWeight := 0.0
-	for _, tc := range tests {
-		timeout := time.Duration(tc.TimeLimitSec * float64(time.Second))
-		var stdout, stderr string
-		var exitCode int
-		var timedOut bool
-		var runtime time.Duration
-		if tc.UnittestCode != nil && tc.UnittestName != nil {
-			stdout, stderr, exitCode, timedOut, runtime = executePythonUnit(tmpDir, mainFile, *tc.UnittestCode, *tc.UnittestName, timeout)
-		} else {
-			stdout, stderr, exitCode, timedOut, runtime = executePythonDir(tmpDir, mainFile, tc.Stdin, timeout)
-		}
+        for _, tc := range tests {
+                timeout := time.Duration(tc.TimeLimitSec * float64(time.Second))
+                var stdout, stderr string
+                var exitCode int
+                var timedOut bool
+                var runtime time.Duration
+                var actualReturn *string
+                mode := strings.TrimSpace(tc.ExecutionMode)
+                if mode == "" {
+                        if tc.UnittestName != nil {
+                                mode = "unittest"
+                        } else if tc.FunctionName != nil {
+                                mode = "function"
+                        } else {
+                                mode = "stdin_stdout"
+                        }
+                }
 
-		status := "passed"
-		if tc.UnittestCode != nil && tc.UnittestName != nil {
-			if timedOut {
-				status = "time_limit_exceeded"
-			} else if exitCode != 0 {
-				if strings.Contains(stdout, "===JUDGE:ASSERT_FAIL===") {
-					status = "wrong_output"
-				} else {
-					status = "runtime_error"
-				}
-			}
-		} else {
-			switch {
-			case timedOut:
-				status = "time_limit_exceeded"
-			case exitCode != 0:
-				status = "runtime_error"
-			case strings.TrimSpace(stdout) != strings.TrimSpace(tc.ExpectedStdout):
-				status = "wrong_output"
-			}
-		}
+                var funcMeta *functionCallResult
+                var funcErr error
 
-		res := &Result{SubmissionID: id, TestCaseID: tc.ID, Status: status, ActualStdout: stdout, Stderr: stderr, ExitCode: exitCode, RuntimeMS: int(runtime.Milliseconds())}
-		CreateResult(res)
-		totalWeight += tc.Weight
-		if status != "passed" {
-			allPass = false
-		} else {
+                switch mode {
+                case "unittest":
+                        stdout, stderr, exitCode, timedOut, runtime = executePythonUnit(tmpDir, mainFile, stringOrEmpty(tc.UnittestCode), stringOrEmpty(tc.UnittestName), timeout)
+                case "function":
+                        fn := strings.TrimSpace(stringOrEmpty(tc.FunctionName))
+                        cfg := functionCallConfig{FunctionName: fn, ArgsJSON: tc.FunctionArgs, KwargsJSON: tc.FunctionKwargs, ExpectedJSON: tc.ExpectedReturn}
+                        stdout, stderr, exitCode, timedOut, runtime, funcMeta, funcErr = runFunctionCall(tmpDir, mainFile, cfg, timeout)
+                        if funcErr != nil {
+                                stderr = funcErr.Error()
+                                exitCode = -1
+                        }
+                        if funcMeta != nil {
+                                if funcMeta.Stdout != "" {
+                                        stdout = funcMeta.Stdout
+                                }
+                                if funcMeta.ReturnJSON != nil && *funcMeta.ReturnJSON != "" {
+                                        actualReturn = funcMeta.ReturnJSON
+                                } else if strings.TrimSpace(funcMeta.ReturnRepr) != "" {
+                                        rr := funcMeta.ReturnRepr
+                                        actualReturn = &rr
+                                }
+                                if funcMeta.Traceback != "" {
+                                        stderr = funcMeta.Traceback
+                                }
+                                if funcMeta.Status == "exception" && stderr == "" {
+                                        stderr = funcMeta.Exception
+                                }
+                        }
+                default:
+                        stdout, stderr, exitCode, timedOut, runtime = executePythonDir(tmpDir, mainFile, tc.Stdin, timeout)
+                }
+
+                status := "passed"
+                switch mode {
+                case "unittest":
+                        if timedOut {
+                                status = "time_limit_exceeded"
+                        } else if exitCode != 0 {
+                                if strings.Contains(stdout, "===JUDGE:ASSERT_FAIL===") {
+                                        status = "wrong_output"
+                                } else {
+                                        status = "runtime_error"
+                                }
+                        }
+                case "function":
+                        if funcErr != nil {
+                                status = "runtime_error"
+                        } else if timedOut {
+                                status = "time_limit_exceeded"
+                        } else if funcMeta != nil {
+                                if funcMeta.Status == "exception" {
+                                        status = "runtime_error"
+                                } else if !funcMeta.Passed {
+                                        status = "wrong_output"
+                                }
+                        } else if exitCode != 0 {
+                                status = "runtime_error"
+                        }
+                default:
+                        switch {
+                        case timedOut:
+                                status = "time_limit_exceeded"
+                        case exitCode != 0:
+                                status = "runtime_error"
+                        case strings.TrimSpace(stdout) != strings.TrimSpace(tc.ExpectedStdout):
+                                status = "wrong_output"
+                        }
+                }
+
+                res := &Result{SubmissionID: id, TestCaseID: tc.ID, Status: status, ActualStdout: stdout, Stderr: stderr, ExitCode: exitCode, RuntimeMS: int(runtime.Milliseconds()), ActualReturn: actualReturn}
+                CreateResult(res)
+                totalWeight += tc.Weight
+                if status != "passed" {
+                        allPass = false
+                } else {
 			earnedWeight += tc.Weight
 		}
 	}

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -452,6 +452,7 @@ $: id = $page.params.id
           {#if Array.isArray(results) && results.length}
             <div class="space-y-2">
               {#each results as r, i}
+                {@const mode = r.execution_mode ?? (r.unittest_name ? 'unittest' : r.function_name ? 'function' : 'stdin_stdout')}
                 {#if allowTestDetails || allowTraceback}
                   <details class="collapse collapse-arrow rounded-box bg-base-200">
                     <summary class="collapse-title">
@@ -460,7 +461,12 @@ $: id = $page.params.id
                           <span class="rounded-full bg-base-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-base-content/70">
                             Test {r.test_number ?? i + 1}
                           </span>
-                          {#if allowTestDetails && r.unittest_name}
+                          {#if allowTestDetails && mode === 'function'}
+                            <span class="badge badge-outline badge-info text-xs font-semibold tracking-wide uppercase">Function</span>
+                            {#if r.function_name}
+                              <span class="badge badge-outline text-xs font-semibold tracking-wide">{r.function_name}</span>
+                            {/if}
+                          {:else if allowTestDetails && r.unittest_name}
                             <span class="badge badge-outline badge-primary text-xs font-semibold tracking-wide uppercase">{r.unittest_name}</span>
                           {:else if allowTestDetails && (typeof r.stdin !== 'undefined' || typeof r.expected_stdout !== 'undefined')}
                             <span class="badge badge-outline text-xs font-semibold tracking-wide uppercase">I/O test</span>
@@ -496,7 +502,32 @@ $: id = $page.params.id
                             </svg>
                             Test definition
                           </header>
-                          {#if r.unittest_code}
+                          {#if mode === 'function'}
+                            <div class="grid gap-3 md:grid-cols-2">
+                              <div class="rounded-xl border border-base-300/60 bg-base-200/70 p-3">
+                                <div class="text-xs font-semibold uppercase tracking-wide text-base-content/70">Function</div>
+                                <div class="mt-2 font-mono text-sm">{r.function_name}</div>
+                              </div>
+                              <div class="rounded-xl border border-base-300/60 bg-base-200/70 p-3">
+                                <div class="text-xs font-semibold uppercase tracking-wide text-base-content/70">Expected return</div>
+                                <pre class="mt-2 whitespace-pre-wrap font-mono text-sm leading-relaxed">{r.expected_return ?? '∅'}</pre>
+                              </div>
+                              <div class="rounded-xl border border-base-300/60 bg-base-200/70 p-3">
+                                <div class="text-xs font-semibold uppercase tracking-wide text-base-content/70">Arguments</div>
+                                <pre class="mt-2 whitespace-pre-wrap font-mono text-sm leading-relaxed">{r.function_args ?? '[]'}</pre>
+                              </div>
+                              <div class="rounded-xl border border-base-300/60 bg-base-200/70 p-3">
+                                <div class="text-xs font-semibold uppercase tracking-wide text-base-content/70">Keyword args</div>
+                                <pre class="mt-2 whitespace-pre-wrap font-mono text-sm leading-relaxed">{r.function_kwargs ?? '{}'}</pre>
+                              </div>
+                              {#if r.actual_return}
+                                <div class="rounded-xl border border-base-300/60 bg-base-200/70 p-3 md:col-span-2">
+                                  <div class="text-xs font-semibold uppercase tracking-wide text-base-content/70">Actual return</div>
+                                  <pre class="mt-2 whitespace-pre-wrap font-mono text-sm leading-relaxed">{r.actual_return}</pre>
+                                </div>
+                              {/if}
+                            </div>
+                          {:else if r.unittest_code}
                             {#if r.unittest_name}
                               <div class="badge badge-outline badge-primary mb-3">{r.unittest_name}</div>
                             {/if}


### PR DESCRIPTION
## Summary
- add a sandboxed function runner and persist returned values so automatic tests can execute student-defined functions directly
- extend the assignments test APIs and AI generator workflow to handle both stdin/stdout and function-call cases
- update the teacher UI, run console, and submission results views to configure, run, and review the new function-based tests

## Testing
- `cd backend && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68dd83021398832191255ac80b810162